### PR TITLE
fix: random suffix for the oidc pool & provider

### DIFF
--- a/examples/with-backstage/README.md
+++ b/examples/with-backstage/README.md
@@ -76,6 +76,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | github | ~> 5.38 |
 | google | ~> 5.1 |
 | humanitec | ~> 0.13 |
+| random | ~> 3.5 |
 
 ### Providers
 
@@ -84,6 +85,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | github | ~> 5.38 |
 | google | ~> 5.1 |
 | humanitec | ~> 0.13 |
+| random | ~> 3.5 |
 
 ### Modules
 
@@ -120,6 +122,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | [humanitec_value.backstage_github_org_id](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_humanitec_org](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_humanitec_token](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
+| [random_string.oidc_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ### Inputs
 

--- a/examples/with-backstage/gcp-github.tf
+++ b/examples/with-backstage/gcp-github.tf
@@ -4,6 +4,12 @@ locals {
   cloud_provider       = "gcp"
 }
 
+resource "random_string" "oidc_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
 # Create a role for GitHub Actions to push to GAR using OpenID Connect (OIDC) so we don't need to store GCP credentials in GitHub
 # Reference https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform
 
@@ -12,8 +18,8 @@ module "gh_oidc" {
   source      = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
   version     = "~> 3.1"
   project_id  = var.project_id
-  pool_id     = "htc-ref-arch"
-  provider_id = "htc-ref-arch"
+  pool_id     = "htc-ref-arch-${resource.random_string.oidc_suffix.result}"
+  provider_id = "htc-ref-arch-${resource.random_string.oidc_suffix.result}"
   attribute_mapping = {
     "google.subject"             = "assertion.sub"
     "attribute.actor"            = "assertion.actor"

--- a/examples/with-backstage/provider.tf
+++ b/examples/with-backstage/provider.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.38"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
   }
   required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
GCP prevents to re-use the same id for a OIDC pool & provider for 30 days after deletion. Workaround this by adding a random suffix to both.