### PR TITLE
fix: enable compute api

### DIFF
--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -3,9 +3,10 @@
 # ######################################################################
 resource "google_project_service" "apis" {
   for_each = toset([
-    "cloudresourcemanager.googleapis.com",
-    "container.googleapis.com",
     "artifactregistry.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
   ])
 
   service = each.key


### PR DESCRIPTION
The compute API also needs to be enabled to run the reference-architecture.

Also sorted the list.