### PR TITLE
feat: set oidc attribute condition

### DIFF
--- a/examples/with-backstage/gcp-github.tf
+++ b/examples/with-backstage/gcp-github.tf
@@ -27,6 +27,7 @@ module "gh_oidc" {
     "attribute.repository"       = "assertion.repository"
     "attribute.repository_owner" = "assertion.repository_owner"
   }
+  attribute_condition = "attribute.repository_owner == \"${var.github_org_id}\""
   sa_mapping = {
     (google_service_account.sa.account_id) = {
       sa_name   = google_service_account.sa.name


### PR DESCRIPTION
Setting this will soon be enforced by GCP https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#conditions

While the service account should already be protected, this adds another layer of defence.