### PR TITLE
feat: use resource account

### DIFF
--- a/modules/gke/outputs.tf
+++ b/modules/gke/outputs.tf
@@ -21,7 +21,7 @@ output "zone" {
 }
 
 output "credentials" {
-  value     = jsondecode(base64decode(google_service_account_key.gke_cluster_access_key.private_key))
+  value     = base64decode(google_service_account_key.gke_cluster_access_key.private_key)
   sensitive = true
 }
 

--- a/modules/htc_res_defs/main.tf
+++ b/modules/htc_res_defs/main.tf
@@ -1,18 +1,24 @@
+resource "humanitec_resource_account" "cluster_account" {
+  id   = "${var.prefix}cluster"
+  name = "${var.prefix}cluster"
+  type = "gcp"
+
+  credentials = var.k8s_credentials
+}
+
 resource "humanitec_resource_definition" "k8s_cluster" {
   driver_type = "humanitec/k8s-cluster-gke"
   id          = "${var.prefix}cluster"
   name        = "${var.prefix}cluster"
   type        = "k8s-cluster"
 
+  driver_account = humanitec_resource_account.cluster_account.id
   driver_inputs = {
     values_string = jsonencode({
       "name"         = var.k8s_cluster_name
       "loadbalancer" = var.k8s_loadbalancer
       "project_id"   = var.k8s_project_id
       "zone"         = var.k8s_region
-    }),
-    secrets_string = jsonencode({
-      "credentials" = var.k8s_credentials
     })
   }
 }

--- a/modules/htc_res_defs/variables.tf
+++ b/modules/htc_res_defs/variables.tf
@@ -16,7 +16,7 @@ variable "k8s_region" {
   description = "The region the cluster is in."
 }
 variable "k8s_credentials" {
-  type        = map(any)
+  type        = string
   description = "The credentials used to establish a connection to the cluster."
 }
 variable "environment" {


### PR DESCRIPTION
Use a resource account instead of injecting the credentials directly into the driver.

This prepares us for using temporary credentials in the future.