### PR TITLE
feat: set backstage service-to-service auth key

### DIFF
--- a/examples/with-backstage/README.md
+++ b/examples/with-backstage/README.md
@@ -113,6 +113,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | [humanitec_application.backstage](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
 | [humanitec_resource_definition_criteria.backstage_mysql](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.backstage_postgres](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [humanitec_value.app_config_backend_auth_keys](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_cloud_provider](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_github_app_client_id](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_github_app_client_secret](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
@@ -122,6 +123,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | [humanitec_value.backstage_github_org_id](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_humanitec_org](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_humanitec_token](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
+| [random_bytes.backstage_service_to_service_auth_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/bytes) | resource |
 | [random_string.oidc_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ### Inputs

--- a/examples/with-backstage/backstage-humanitec.tf
+++ b/examples/with-backstage/backstage-humanitec.tf
@@ -77,6 +77,20 @@ resource "humanitec_value" "backstage_cloud_provider" {
   is_secret   = false
 }
 
+resource "random_bytes" "backstage_service_to_service_auth_key" {
+  length = 24
+}
+
+resource "humanitec_value" "app_config_backend_auth_keys" {
+  app_id      = humanitec_application.backstage.id
+  key         = "APP_CONFIG_backend_auth_keys"
+  description = "Backstage service-to-service-auth keys"
+  value = jsonencode([{
+    secret = random_bytes.backstage_service_to_service_auth_key.base64
+  }])
+  is_secret = true
+}
+
 # Configure required resources for backstage
 
 locals {


### PR DESCRIPTION
Setting this key is require while we still have legacy plugins https://backstage.io/docs/auth/service-to-service-auth/#legacy-tokens

Required for https://github.com/humanitec-architecture/backstage/pull/21