### PR TITLE
fix: lock environment type/id

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,6 @@ Once you are finished with the reference architecture, you can remove all provis
 | gar\_repository\_location | Location of the Google Artifact Registry repository, | `string` | n/a | yes |
 | project\_id | GCP Project ID to provision resources in. | `string` | n/a | yes |
 | region | GCP Region to provision resources in. | `string` | n/a | yes |
-| environment | The environment to associate the reference architecture with. | `string` | `null` | no |
-| environment\_type | The environment type to associate the reference architecture with. | `string` | `"development"` | no |
 | gar\_repository\_id | Google Artifact Registry repository ID. | `string` | `"htc-ref-arch"` | no |
 | github\_org\_id | GitHub org id (required for Backstage) | `string` | `null` | no |
 | humanitec\_org\_id | Humanitec Organization ID. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,6 @@ module "base" {
   region           = var.region
   humanitec_prefix = var.humanitec_prefix
   humanitec_org_id = var.humanitec_org_id
-  environment      = var.environment
-  environment_type = var.environment_type
 
   gar_repository_id       = var.gar_repository_id
   gar_repository_location = var.gar_repository_location

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -32,8 +32,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| environment | The environment to associate the reference architecture with. | `string` | n/a | yes |
-| environment\_type | The environment type to associate the reference architecture with. | `string` | n/a | yes |
 | project\_id | GCP Project ID to provision resources in. | `string` | n/a | yes |
 | region | GCP Region to provision resources in. | `string` | n/a | yes |
 | gar\_repository\_id | ID of the Google Artifact Registry repository (not created if empty). | `string` | `null` | no |

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -64,8 +64,6 @@ module "res_defs" {
   k8s_loadbalancer        = module.k8s.loadbalancer
   k8s_region              = var.region
   k8s_project_id          = var.project_id
-  environment             = var.environment
-  environment_type        = var.environment_type
   prefix                  = var.humanitec_prefix
   humanitec_cloud_account = module.credentials.humanitec_cloud_account
 }

--- a/modules/base/terraform.tfvars.example
+++ b/modules/base/terraform.tfvars.example
@@ -1,10 +1,4 @@
 
-# The environment to associate the reference architecture with.
-environment = ""
-
-# The environment type to associate the reference architecture with.
-environment_type = ""
-
 # ID of the Google Artifact Registry repository (not created if empty).
 gar_repository_id = ""
 

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -22,16 +22,6 @@ variable "humanitec_org_id" {
 # OPTIONAL INPUTS
 ##########################################
 
-variable "environment" {
-  type        = string
-  description = "The environment to associate the reference architecture with."
-}
-
-variable "environment_type" {
-  type        = string
-  description = "The environment type to associate the reference architecture with."
-}
-
 variable "humanitec_prefix" {
   type        = string
   description = "A prefix that will be attached to all IDs created in Humanitec."

--- a/modules/htc_res_defs/README.md
+++ b/modules/htc_res_defs/README.md
@@ -34,12 +34,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| environment | The environment to use for matching criteria. | `string` | n/a | yes |
-| environment\_type | The environment type to use for matching criteria. | `string` | n/a | yes |
 | humanitec\_cloud\_account | The ID of the Humanitec Cloud Account. | `string` | n/a | yes |
 | k8s\_cluster\_name | The name of the cluster. | `string` | n/a | yes |
 | k8s\_loadbalancer | IP address or Host of the load balancer used by the ingress controller. | `string` | n/a | yes |
 | k8s\_project\_id | The GCP Project the cluster is in. | `string` | n/a | yes |
 | k8s\_region | The region the cluster is in. | `string` | n/a | yes |
+| environment | The environment to use for matching criteria. | `string` | `"development"` | no |
+| environment\_type | The environment type to use for matching criteria. | `string` | `"development"` | no |
 | prefix | A prefix that will be attached to all IDs created in Humanitec. | `string` | `""` | no |
 <!-- END_TF_DOCS -->

--- a/modules/htc_res_defs/main.tf
+++ b/modules/htc_res_defs/main.tf
@@ -20,6 +20,7 @@ resource "humanitec_resource_definition_criteria" "k8s_cluster" {
   env_id                 = var.environment
   env_type               = var.environment_type
 
+  force_delete = true
 }
 
 
@@ -40,6 +41,8 @@ resource "humanitec_resource_definition_criteria" "k8s_namespace" {
   resource_definition_id = humanitec_resource_definition.k8s_namespace.id
   env_id                 = var.environment
   env_type               = var.environment_type
+
+  force_delete = true
 }
 
 
@@ -53,7 +56,10 @@ module "default_postgres" {
 
 resource "humanitec_resource_definition_criteria" "default_postgres" {
   resource_definition_id = module.default_postgres.id
-  env_type               = var.environment
+  env_id                 = var.environment
+  env_type               = var.environment_type
+
+  force_delete = true
 }
 
 module "default_mysql" {
@@ -64,5 +70,8 @@ module "default_mysql" {
 
 resource "humanitec_resource_definition_criteria" "default_mysql" {
   resource_definition_id = module.default_mysql.id
-  env_type               = var.environment
+  env_id                 = var.environment
+  env_type               = var.environment_type
+
+  force_delete = true
 }

--- a/modules/htc_res_defs/terraform.tfvars.example
+++ b/modules/htc_res_defs/terraform.tfvars.example
@@ -1,9 +1,9 @@
 
 # The environment to use for matching criteria.
-environment = ""
+environment = "development"
 
 # The environment type to use for matching criteria.
-environment_type = ""
+environment_type = "development"
 
 # The ID of the Humanitec Cloud Account.
 humanitec_cloud_account = ""

--- a/modules/htc_res_defs/variables.tf
+++ b/modules/htc_res_defs/variables.tf
@@ -18,10 +18,12 @@ variable "k8s_region" {
 variable "environment" {
   type        = string
   description = "The environment to use for matching criteria."
+  default     = "development"
 }
 variable "environment_type" {
   type        = string
   description = "The environment type to use for matching criteria."
+  default     = "development"
 }
 variable "prefix" {
   type        = string

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,10 +1,4 @@
 
-# The environment to associate the reference architecture with.
-environment = ""
-
-# The environment type to associate the reference architecture with.
-environment_type = "development"
-
 # Google Artifact Registry repository ID.
 gar_repository_id = "htc-ref-arch"
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,18 +28,6 @@ variable "gar_repository_id" {
 # OPTIONAL INPUTS
 ##########################################
 
-variable "environment" {
-  type        = string
-  description = "The environment to associate the reference architecture with."
-  default     = null
-}
-
-variable "environment_type" {
-  type        = string
-  description = "The environment type to associate the reference architecture with."
-  default     = "development"
-}
-
 variable "humanitec_prefix" {
   type        = string
   description = "A prefix that will be attached to all IDs created in Humanitec."


### PR DESCRIPTION
Remove the ability to customize the `environment` / `environment_type` for now as things like backstage rely that k8s-cluster & k8s-namespace are matched to an environment called `development` https://github.com/humanitec-architecture/backstage/blob/main/.github/workflows/deploy.yaml#L139